### PR TITLE
Turning display off while playing PVR-TV/PVR-radio

### DIFF
--- a/script.xbmc.lcd/lcdmain.py
+++ b/script.xbmc.lcd/lcdmain.py
@@ -117,9 +117,9 @@ def process_lcd():
         g_lcdproc.SetBackLight(1)
         bBacklightDimmed = False
     
-      if mode == LCD_MODE.LCD_MODE_MUSIC:
+      if mode == LCD_MODE.LCD_MODE_MUSIC or mode == LCD_MODE.LCD_MODE_PVRRADIO:
         g_lcdproc.DisableOnPlayback(False, True)
-      elif mode == LCD_MODE.LCD_MODE_VIDEO:
+      elif mode == LCD_MODE.LCD_MODE_VIDEO or mode == LCD_MODE.LCD_MODE_PVRTV:
         g_lcdproc.DisableOnPlayback(True, False)
       else:
         g_lcdproc.DisableOnPlayback(False, False)


### PR DESCRIPTION
For the time being (no separate GUI-setting for 'DisableOnPlayback') this makes turning the backlight off more consequent within PVR-module-playbacks.

As described in
http://www.vdr-portal.de/board60-linux/board62-software/board95-xbmc/p1119078-wip-xbmc-lcdproc-support-als-python-addon-tester-gesucht/#post1119078
and
http://www.vdr-portal.de/board60-linux/board62-software/board95-xbmc/p1119171-wip-xbmc-lcdproc-support-als-python-addon-tester-gesucht/#post1119171

Cheers,
Chriss
