### PR TITLE
Lcdproc telnet server doesn't support telnet command IAC.

### DIFF
--- a/resources/lib/lcdproc.py
+++ b/resources/lib/lcdproc.py
@@ -91,7 +91,9 @@ class LCDProc(LcdBase):
 
     try:
       # Send to server
-      self.tn.write(sendcmd)
+      sock = self.tn.get_socket()
+      if sock is not None:
+        sock.send(sendcmd)
     except:
       # Something bad happened, abort
       log(xbmc.LOGERROR, "SendCommand: Telnet exception - send")


### PR DESCRIPTION
This leads to an incorrect display of character with code 255.
To correctly display needs to use the raw socket instead telnet.
