### PR TITLE
Use XBMC system time instead python's local time

### DIFF
--- a/resources/lib/infolabels.py
+++ b/resources/lib/infolabels.py
@@ -96,6 +96,12 @@ def InfoLabel_PlayingLiveTV():
 def InfoLabel_PlayingLiveRadio():
   return xbmc.getCondVisibility("PVR.IsPlayingRadio")
 
+def InfoLabel_GetSystemTime(format):
+  cmd = "System.Time"
+  if len(format):
+    cmd += "(" + format + ")"
+  return xbmc.getInfoLabel(cmd)
+
 def InfoLabel_GetPlayerTime():
   return xbmc.getInfoLabel("Player.Time")
 


### PR DESCRIPTION
Method time.strftime("% X") always gives the time in format h:MM.
However, in some countries (such as Russia), the time is displayed in the format HH:MM.
This patch displays the time in the format prescribed by the user.
