### PR TITLE
Disable spin animation on pause

### DIFF
--- a/resources/lib/lcdproc_extra_imon.py
+++ b/resources/lib/lcdproc_extra_imon.py
@@ -191,6 +191,10 @@ class LCDproc_extra_imon(LCDproc_extra_base):
     if icon == LCD_EXTRAICONS.LCD_EXTRAICON_PLAYING:
       self._SetIconStateDo(IMON_ICONS.ICON_SPINDISC, state)
 
+    elif icon == LCD_EXTRAICONS.LCD_EXTRAICON_PAUSE:
+      if state:
+        self._SetIconStateDo(IMON_ICONS.ICON_SPINDISC, False)
+
     # Icons used for "Modes" category
     elif icon == LCD_EXTRAICONS.LCD_EXTRAICON_MOVIE:
       self.m_iOutputValueIcons &= IMON_ICONS.ICON_CLEAR_TOPROW


### PR DESCRIPTION
XBMC users from the forum "xbmc.ru" asked me to turn off the spin animation in pause mode.
If you think that this is unnecessary, I will not insist.
