### PR TITLE
Alignment on the center of the big clock

### DIFF
--- a/resources/lib/lcdbase.py
+++ b/resources/lib/lcdbase.py
@@ -84,6 +84,7 @@ class LcdBase():
     self.m_timeDisableOnPlayTimer = time.time()
     self.m_lcdMode = [None] * LCD_MODE.LCD_MODE_MAX
     self.m_extraBars = [None] * (LCD_EXTRABARS_MAX + 1)
+    self.m_bCenterBigDigits = False
     self.m_bCurrentlyDimmed = False
     self.m_iDimOnPlayDelay = 0
     self.m_strInfoLabelEncoding = "utf-8" # http://forum.xbmc.org/showthread.php?tid=125492&pid=1045926#pid1045926
@@ -276,6 +277,11 @@ class LcdBase():
         if allowemptylines != None:
           if str(allowemptylines.text).lower() in ["on", "true"]:
             self.m_bAllowEmptyLines = True
+
+        centerbigdigits = element.find("centerbigdigits")
+        if centerbigdigits != None:
+          if str(centerbigdigits.text).lower() in ["on", "true"]:
+            self.m_bCenterBigDigits = True
 
         # check for disableplayindicatoronpause setting
         self.m_bDisablePlayIndicatorOnPause = False

--- a/resources/lib/lcdproc.py
+++ b/resources/lib/lcdproc.py
@@ -71,6 +71,7 @@ class LCDProc(LcdBase):
     self.m_iProgressBarLine = -1
     self.m_strIconName = "BLOCK_FILLED"
     self.m_iBigDigits = int(8) # 12:45:78 / colons count as digit
+    self.m_iOffset = 1
     self.m_strSetLineCmds = ""
     self.m_cExtraIcons = None
     self.m_vPythonVersion = sys.version_info
@@ -438,8 +439,18 @@ class LCDProc(LcdBase):
 
     iStringLength = int(len(strTimeString))
 
+    if self.m_bCenterBigDigits:
+      iColons = strTimeString.count(":")
+      iWidth  = 3 * (iStringLength - iColons) + iColons
+      iOffset = 1 + max(self.m_iColumns - iWidth, 0) / 2
+
     if iStringLength > self.m_iBigDigits:
       iStringOffset = len(strTimeString) - self.m_iBigDigits
+      iOffset = 1;
+
+    if self.m_iOffset != iOffset:
+      self.ClearBigDigits()
+      self.m_iOffset = iOffset
 
     for i in range(int(iStringOffset), int(iStringLength)):
       if self.m_strDigits[iDigitCount] != strTimeString[i] or bForceUpdate:


### PR DESCRIPTION
This is the latest "cosmetic" patch.
The big clock look better if it centered, and for playing time better left alignment.
This patch calculates the optimal offset for both modes.
