### PR TITLE
Use sendall instead send

### DIFF
--- a/resources/lib/lcdproc.py
+++ b/resources/lib/lcdproc.py
@@ -94,7 +94,7 @@ class LCDProc(LcdBase):
     try:
       # Send to server via raw socket to prevent telnetlib tampering with
       # certain chars (especially 0xFF -> telnet IAC)
-      self.tnsocket.send(sendcmd)
+      self.tnsocket.sendall(sendcmd)
     except:
       # Something bad happened, abort
       log(xbmc.LOGERROR, "SendCommand: Telnet exception - send")


### PR DESCRIPTION
Hi, it's me again!
I think it is better to use "sendall" instead of "send", because theoretically "send" can not fully transmit the commands.
Here is the code of the method "write" from library telnet:

<pre><code>
     def write(self, buffer):
         """Write a string to the socket, doubling any IAC characters.
 
         Can block if the connection is blocked.  May raise
         socket.error if the connection is closed.
 
         """
         if IAC in buffer:
             buffer = buffer.replace(IAC, IAC+IAC)
         self.msg("send %r", buffer)
         self.sock.sendall(buffer)
</code></pre>

They also use sendall.
