### PR TITLE
Add options to enable time on progressbar

### DIFF
--- a/resources/LCD.xml.defaults
+++ b/resources/LCD.xml.defaults
@@ -6,6 +6,12 @@
 
    <!-- progressbarsurroundings: put progress bars in square brackets (on/off) -->
    <!--progressbarsurroundings>off</progressbarsurroundings-->
+   
+   <!-- progressbartime: put time Elapsed/Total before and after progress bars (on/off) -->
+   <!--progressbartime>on</progressbartime-->
+   
+   <!-- progressbarblank: character to use as non-filled progressbar -->
+   <!--progressbarblank>-</progressbarblank-->
 
    <!-- icontextoffset: offset for text displayed after any play/pause icons -->
    <!--icontextoffset>2</icontextoffset-->

--- a/resources/lib/lcdbase.py
+++ b/resources/lib/lcdbase.py
@@ -269,6 +269,22 @@ class LcdBase():
           if str(progressbarSurroundings.text).lower() in ["on", "true"]:
             self.m_bProgressbarSurroundings = True
 
+        # check for progressbartime setting
+        self.m_bProgressbarTime = False
+        
+        progressbarTime = element.find("progressbartime")
+        if progressbarTime != None:
+          if str(progressbarTime.text).lower() in ["on", "true"]:
+            self.m_bProgressbarTime = True
+
+        # apply progressbarblank
+        self.m_bProgressbarBlank = " "
+        
+        progressbarBlank = element.find("progressbarblank")
+        if progressbarBlank != None:
+          self.m_bProgressbarBlank = str(progressbarBlank.text)[0]
+        
+            
         # icontext offset setting
         self.m_iIconTextOffset = 2
 

--- a/resources/lib/lcdproc.py
+++ b/resources/lib/lcdproc.py
@@ -569,6 +569,8 @@ class LCDProc(LcdBase):
 
     if dictDescriptor['type'] == LCD_LINETYPE.LCD_LINETYPE_BIGSCREEN:
       strLineLong = self.GetBigDigitTime(mode)
+    elif dictDescriptor['type'] == LCD_LINETYPE.LCD_LINETYPE_PROGRESS and self.m_bProgressbarTime:
+      strLineLong = InfoLabel_GetPlayerTime() + self.m_bProgressbarBlank * (self.m_iColumns - len(InfoLabel_GetPlayerTime()) - len(InfoLabel_GetPlayerDuration())) + InfoLabel_GetPlayerDuration()
     else:
       strLineLong = strLine
 
@@ -595,7 +597,12 @@ class LCDProc(LcdBase):
         self.SetBigDigits(strLineLong, bExtraForce)
       # progressbar line
       elif dictDescriptor['type'] == LCD_LINETYPE.LCD_LINETYPE_PROGRESS:
-        self.m_strSetLineCmds += "widget_set xbmc lineProgress%i %i %i %i\n" % (ln, iStartX, ln, self.m_iProgressBarWidth)
+        if self.m_bProgressbarTime:
+          # My codes is ugly but it works. Any improvement is welcome.  
+          self.m_strSetLineCmds += "widget_set xbmc lineProgress%i %i %i %i\n" % (ln, iStartX + len(InfoLabel_GetPlayerTime()), ln, self.m_iProgressBarWidth - int((len(InfoLabel_GetPlayerDuration()) + len(InfoLabel_GetPlayerTime())) * self.m_iProgressBarWidth / self.m_iColumns))
+          self.m_strSetLineCmds += "widget_set xbmc lineScroller%i %i %i %i %i %s %i \"%s\"\n" % (ln, iStartX, ln, self.m_iColumns, ln, strScrollMode, iScrollSpeed, re.escape(strLineLong))
+        else:
+          self.m_strSetLineCmds += "widget_set xbmc lineProgress%i %i %i %i\n" % (ln, iStartX, ln, self.m_iProgressBarWidth)
       # everything else (text, icontext)
       else:
         if len(strLineLong) < iMaxLineLen and dictDescriptor['align'] != LCD_LINEALIGN.LCD_LINEALIGN_LEFT:


### PR DESCRIPTION
This code will create time elapsed/totat at begin/end of progressbar like this:
00:12:34 |||||||||||||-------- 01:23:45
Useful for who has glcd or char with 16+ columns.
![2015-08-17 08 03 06](https://cloud.githubusercontent.com/assets/6429419/9422698/1e73b9e2-48ca-11e5-90ba-8072e591df0b.jpg)
