### PR TITLE
Added support for displaying volume level during changing

### DIFF
--- a/lcdmain.py
+++ b/lcdmain.py
@@ -2,21 +2,21 @@
     XBMC LCDproc addon
     Copyright (C) 2012 Team XBMC
     Copyright (C) 2012 Daniel 'herrnst' Scheller
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License along
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
@@ -45,9 +45,9 @@ global g_lcdproc
 def initGlobals():
   global g_failedConnectionNotified
   global g_initialConnectAttempt
-  global g_lcdproc 
+  global g_lcdproc
 
-  g_failedConnectionNotified = False   
+  g_failedConnectionNotified = False
   g_initialConnectAttempt = True
   settings_initGlobals()
   g_lcdproc = LCDProc()
@@ -72,9 +72,10 @@ def HandleConnectionNotification(bConnectSuccess):
       g_failedConnectionNotified = True
 
 # returns mode identifier based on currently playing media/active navigation
-def getLcdMode():                 
+def getLcdMode():
   ret = LCD_MODE.LCD_MODE_GENERAL
 
+  volChanging = InfoLabel_IsVolumeChanging()
   navActive = InfoLabel_IsNavigationActive()
   screenSaver = InfoLabel_IsScreenSaverActive()
   playingVideo = InfoLabel_PlayingVideo()
@@ -83,7 +84,9 @@ def getLcdMode():
   playingPVRTV = InfoLabel_PlayingLiveTV()
   playingPVRRadio = InfoLabel_PlayingLiveRadio()
 
-  if navActive:
+  if volChanging:
+    ret = LCD_MODE.LCD_MODE_VOLCHANGING
+  elif navActive:
     ret = LCD_MODE.LCD_MODE_NAVIGATION
   elif screenSaver:
     ret = LCD_MODE.LCD_MODE_SCREENSAVER
@@ -97,7 +100,7 @@ def getLcdMode():
     ret = LCD_MODE.LCD_MODE_VIDEO
   elif playingMusic:
     ret = LCD_MODE.LCD_MODE_MUSIC
-   
+
   return ret
 
 def process_lcd():

--- a/resources/LCD.xml.defaults
+++ b/resources/LCD.xml.defaults
@@ -16,7 +16,7 @@
    <!-- centerbigdigits: (try to) align big numbers centered on the display (on/off) -->
    <!--centerbigdigits>off</centerbigdigits-->
 
-   <!-- disableplayindicatoronpause: turn off any playing indicator (extra stuff) when pausing playback (on/off) --> 
+   <!-- disableplayindicatoronpause: turn off any playing indicator (extra stuff) when pausing playback (on/off) -->
    <!--disableplayindicatoronpause>off</disableplayindicatoronpause-->
 
    <navigation>
@@ -44,7 +44,7 @@
       <line>$INFO[VideoPlayer.Title]</line>
       <line>$INFO[LCD.ProgressBar]</line>
       <line>Freemem: $INFO[System.FreeMemory]</line>
-   </tvshow> 
+   </tvshow>
    <general>
       <line>XBMC running...</line>
       <line>$INFO[System.Time] $INFO[System.Date]</line>
@@ -74,4 +74,8 @@
       <line>$INFO[LCD.PlayIcon] $INFO[Player.Time]/$INFO[Player.Duration]</line>
       <line>$INFO[LCD.ProgressBar]</line>
    </pvrradio>
+   <volchanging>
+      <line>Volume: $INFO[LCD.PlayerVolume]</line>
+      <line>$INFO[LCD.ProgressBar]</line>
+   </volchanging>
 </lcd>

--- a/resources/lib/infolabels.py
+++ b/resources/lib/infolabels.py
@@ -1,24 +1,24 @@
 '''
     XBMC LCDproc addon
     Copyright (C) 2012 Team XBMC
-    
+
     InfoLabel handling
     Copyright (C) 2012 Daniel 'herrnst' Scheller
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License along
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
@@ -57,7 +57,7 @@ class WINDOW_IDS:
   WINDOW_PICTURES              = 10002
   WINDOW_DIALOG_VOLUME_BAR     = 10104
   WINDOW_DIALOG_KAI_TOAST      = 10107
-  
+
 g_StreamPrefixes = [ \
  "http", "https", "tcp",   "udp",    "rtp",  \
  "sdp",  "mms",   "mmst",  "mmsh",   "rtsp", \
@@ -113,7 +113,7 @@ def InfoLabel_PlayingVideo():
   return InfoLabel_GetBool("Player.HasVideo")
 
 def InfoLabel_PlayingTVShow():
-  if InfoLabel_PlayingVideo() and len(InfoLabel_GetInfoLabel("VideoPlayer.TVShowTitle")): 
+  if InfoLabel_PlayingVideo() and len(InfoLabel_GetInfoLabel("VideoPlayer.TVShowTitle")):
     return True
   else:
     return False
@@ -201,9 +201,17 @@ def InfoLabel_IsScreenSaverActive():
 def InfoLabel_IsMuted():
   return InfoLabel_GetBool("Player.Muted")
 
+def InfoLabel_IsVolumeChanging():
+  return InfoLabel_WindowIsActive(WINDOW_IDS.WINDOW_DIALOG_VOLUME_BAR)
+
 def InfoLabel_GetVolumePercent():
   volumedb = float(string.replace(string.replace(InfoLabel_GetInfoLabel("Player.Volume"), ",", "."), " dB", ""))
   return (100 * (60.0 + volumedb) / 60)
+
+def InfoLabel_GetPlayerVolumeText():
+  if InfoLabel_IsMuted():
+    return "[Mute]"
+  return InfoLabel_GetInfoLabel("Player.Volume");
 
 def InfoLabel_GetPlayerTimeSecs():
   currentTimeAr = InfoLabel_GetPlayerTime().split(":")
@@ -244,7 +252,7 @@ def InfoLabel_IsNavigationActive():
   if menu != g_InfoLabel_oldMenu or subMenu != g_InfoLabel_oldSubMenu or (g_InfoLabel_navTimer + navtimeout) > time.time():
     ret = True
     if menu != g_InfoLabel_oldMenu or subMenu != g_InfoLabel_oldSubMenu:
-      g_InfoLabel_navTimer = time.time()      
+      g_InfoLabel_navTimer = time.time()
     g_InfoLabel_oldMenu = menu
     g_InfoLabel_oldSubMenu = subMenu
 

--- a/resources/lib/lcdbase.py
+++ b/resources/lib/lcdbase.py
@@ -2,21 +2,21 @@
     XBMC LCDproc addon
     Copyright (C) 2012 Team XBMC
     Copyright (C) 2012 Daniel 'herrnst' Scheller
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License along
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
@@ -47,7 +47,7 @@ from charset_hd44780 import *
 
 # global functions
 def log(loglevel, msg):
-  xbmc.log("### [%s] - %s" % (__scriptname__,msg,),level=loglevel ) 
+  xbmc.log("### [%s] - %s" % (__scriptname__,msg,),level=loglevel )
 
 class LCD_MODE:
   LCD_MODE_GENERAL     = 0
@@ -59,7 +59,8 @@ class LCD_MODE:
   LCD_MODE_XBE_LAUNCH  = 6
   LCD_MODE_PVRTV       = 7
   LCD_MODE_PVRRADIO    = 8
-  LCD_MODE_MAX         = 9
+  LCD_MODE_VOLCHANGING = 9
+  LCD_MODE_MAX         = 10
 
 class LCD_LINETYPE:
   LCD_LINETYPE_TEXT      = "text"
@@ -72,7 +73,7 @@ class LCD_LINEALIGN:
   LCD_LINEALIGN_CENTER = 1
   LCD_LINEALIGN_RIGHT  = 2
 
-g_dictEmptyLineDescriptor = {} 
+g_dictEmptyLineDescriptor = {}
 g_dictEmptyLineDescriptor['type'] = LCD_LINETYPE.LCD_LINETYPE_TEXT
 g_dictEmptyLineDescriptor['startx'] = int(0)
 g_dictEmptyLineDescriptor['text'] = str("")
@@ -124,11 +125,11 @@ class LcdBase():
   def Suspend(self):
     pass
 
-# @abstractmethod   
+# @abstractmethod
   def Resume(self):
     pass
 
-# @abstractmethod   
+# @abstractmethod
   def SetBackLight(self, iLight):
     pass
 
@@ -136,27 +137,27 @@ class LcdBase():
   def SetContrast(self, iContrast):
     pass
 
-# @abstractmethod  
+# @abstractmethod
   def SetBigDigits(self, strTimeString, bForceUpdate):
     pass
 
-# @abstractmethod   
+# @abstractmethod
   def ClearLine(self, iLine):
     pass
 
-# @abstractmethod     
+# @abstractmethod
   def SetLine(self, mode, iLine, strLine, dictDescriptor, bForce):
     pass
 
-# @abstractmethod     
+# @abstractmethod
   def ClearDisplay(self):
     pass
 
-# @abstractmethod     
+# @abstractmethod
   def FlushLines(self):
     pass
-    
-# @abstractmethod	
+
+# @abstractmethod
   def GetColumns(self):
     pass
 
@@ -252,7 +253,7 @@ class LcdBase():
     for element in doc.getiterator():
       #PARSE LCD infos
       if element.tag == "lcd":
-        # load our settings  
+        # load our settings
 
         # apply scrollseparator
         scrollSeparator = element.find("scrollseparator")
@@ -335,7 +336,7 @@ class LcdBase():
 
         tmpMode = element.find("navigation")
         self.LoadMode(tmpMode, LCD_MODE.LCD_MODE_NAVIGATION)
-    
+
         tmpMode = element.find("screensaver")
         self.LoadMode(tmpMode, LCD_MODE.LCD_MODE_SCREENSAVER)
 
@@ -348,6 +349,9 @@ class LcdBase():
         tmpMode = element.find("pvrradio")
         self.LoadMode(tmpMode, LCD_MODE.LCD_MODE_PVRRADIO)
 
+        tmpMode = element.find("volchanging")
+        self.LoadMode(tmpMode, LCD_MODE.LCD_MODE_VOLCHANGING)
+
         bHaveSkin = True
 
         # LCD.xml parsed successfully, so reset warning flag
@@ -358,7 +362,7 @@ class LcdBase():
   def LoadMode(self, node, mode):
     # clear mode (probably overriding defaults), assume the user knows what he wants if an empty node is given
     self.m_lcdMode[mode] = []
-    
+
     if node == None:
       log(xbmc.LOGWARNING, "Empty Mode %d, consider checking LCD.xml" % (mode))
 
@@ -391,7 +395,7 @@ class LcdBase():
       else:
         # prepare text line for XBMC's expected encoding
         linetext = line.text.strip().encode(self.m_strInfoLabelEncoding, "ignore")
-      
+
       # make sure linetext has something so re.match won't fail
       if linetext != "":
         timematch = re.match(timeregex, linetext, flags=re.IGNORECASE)
@@ -469,7 +473,7 @@ class LcdBase():
 
     # loop to catch nested tags
     loopcount = 5
-    
+
     # start with passed string
     mangledline = strtext
 
@@ -497,15 +501,37 @@ class LcdBase():
     while (outLine < int(self.GetRows()) and inLine < len(self.m_lcdMode[mode])):
       #parse the progressbar infolabel by ourselfs!
       if self.m_lcdMode[mode][inLine]['type'] == LCD_LINETYPE.LCD_LINETYPE_PROGRESS:
-        # get playtime and duration and convert into seconds
-        percent = InfoLabel_GetProgressPercent()
-        pixelsWidth = self.SetProgressBar(percent, self.m_lcdMode[mode][inLine]['endx'])
-        line = "p" + str(pixelsWidth)
+        if mode == LCD_MODE.LCD_MODE_VOLCHANGING:
+          # get volume percentage
+          percent = InfoLabel_GetVolumePercent()
+          if InfoLabel_IsMuted():
+            percent = 0
+          endx = self.m_lcdMode[mode][inLine]['endx']
+          pixelsWidth = self.SetProgressBar(percent, endx)
+          line = str(pixelsWidth)
+          log(xbmc.LOGDEBUG, "Volume changing: %s: %d%%, Muted: %s" % (InfoLabel_GetInfoLabel("Player.Volume"), percent, InfoLabel_GetInfoLabel("Player.Muted")))
+          log(xbmc.LOGDEBUG, "Volume changing: line: %s, endx: %d" % (line, endx))
+        else:
+          # get playtime and duration and convert into seconds
+          percent = InfoLabel_GetProgressPercent()
+          pixelsWidth = self.SetProgressBar(percent, self.m_lcdMode[mode][inLine]['endx'])
+          line = "p" + str(pixelsWidth)
       else:
         if self.m_lcdMode[mode][inLine]['type'] == LCD_LINETYPE.LCD_LINETYPE_ICONTEXT:
           self.SetPlayingStateIcon()
 
-        srcline = InfoLabel_GetInfoLabel(self.m_lcdMode[mode][inLine]['text'])
+        srcline = self.m_lcdMode[mode][inLine]['text']
+        # Handle special player volume level
+        if self.m_vPythonVersion < (2, 7):
+          srcline = re.sub(re.escape("$INFO[LCD.PlayerVolume]"), InfoLabel_GetPlayerVolumeText(), srcline).strip()
+        else:
+          srcline = re.sub(re.escape("$INFO[LCD.PlayerVolume]"), InfoLabel_GetPlayerVolumeText(), srcline, flags=re.IGNORECASE).strip()
+
+        if mode == LCD_MODE.LCD_MODE_VOLCHANGING:
+          log(xbmc.LOGDEBUG, "lcdproc render line: " + srcline)
+        srcline = InfoLabel_GetInfoLabel(srcline)
+        if mode == LCD_MODE.LCD_MODE_VOLCHANGING:
+          log(xbmc.LOGDEBUG, "lcdproc rendered: " + srcline)
 
         if len(srcline) > 0:
           srcline = self.StripBBCode(srcline)
@@ -556,7 +582,7 @@ class LcdBase():
       doDim = True
     elif not InfoLabel_IsPlayerPaused() and (self.DoDimOnVideo(mode) or self.DoDimOnMusic(mode)):
       doDim = True
-    
+
     if doDim:
       if not self.m_bCurrentlyDimmed:
         if (self.m_timeDisableOnPlayTimer + self.m_iDimOnPlayDelay) < time.time():
@@ -637,7 +663,7 @@ class LcdBase():
         self.m_cExtraIcons.SetIconState(LCD_EXTRAICONS.LCD_EXTRAICON_SPDIF, True)
       else:
         self.m_cExtraIcons.SetIconState(LCD_EXTRAICONS.LCD_EXTRAICON_SPDIF, False)
-      
+
       if isvideo:
         strVideoCodec = str(InfoLabel_GetInfoLabel("VideoPlayer.VideoCodec")).lower()
         strAudioCodec = str(InfoLabel_GetInfoLabel("VideoPlayer.AudioCodec")).lower()
@@ -688,7 +714,7 @@ class LcdBase():
       if self.m_strOldAudioCodec != strAudioCodec:
         # work only when audio codec changed
         self.m_strOldAudioCodec = strAudioCodec
-      
+
         # any mpeg audio
         if strAudioCodec in ["mpga", "mp2"]:
           self.m_cExtraIcons.SetIconState(LCD_EXTRAICONS.LCD_EXTRAICON_ACODEC_MPEG, True)
@@ -709,7 +735,7 @@ class LcdBase():
         elif strAudioCodec in ["ogg", "vorbis"]:
           self.m_cExtraIcons.SetIconState(LCD_EXTRAICONS.LCD_EXTRAICON_ACODEC_OGG, True)
 
-        # any wma        
+        # any wma
         elif strAudioCodec in ["wma", "wmav2"]:
           if isvideo:
             self.m_cExtraIcons.SetIconState(LCD_EXTRAICONS.LCD_EXTRAICON_ACODEC_VWMA, True)

--- a/resources/lib/lcdproc.py
+++ b/resources/lib/lcdproc.py
@@ -2,21 +2,21 @@
     XBMC LCDproc addon
     Copyright (C) 2012 Team XBMC
     Copyright (C) 2012 Daniel 'herrnst' Scheller
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License along
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
@@ -45,8 +45,8 @@ from lcdproc_extra_mdm166a import *
 from infolabels import *
 
 def log(loglevel, msg):
-  xbmc.log("### [%s] - %s" % (__scriptname__,msg,), level=loglevel) 
-  
+  xbmc.log("### [%s] - %s" % (__scriptname__,msg,), level=loglevel)
+
 MAX_ROWS = 20
 MAX_BIGDIGITS = 20
 INIT_RETRY_INTERVAL = 2
@@ -101,14 +101,14 @@ class LCDProc(LcdBase):
 
     # Update last socketaction timestamp
     self.m_timeLastSockAction = time.time()
-    
+
     # Repeat for number of found commands
     for i in range(1, (countcmds + 1)):
       # Read in (multiple) responses
       while True:
         try:
           # Read server reply
-          reply = self.tn.read_until("\n",3)            
+          reply = self.tn.read_until("\n",3)
         except:
           # (Re)read failed, abort
           log(xbmc.LOGERROR, "SendCommand: Telnet exception - reread")
@@ -124,9 +124,9 @@ class LCDProc(LcdBase):
         elif reply[:9] == 'menuevent':
           continue
 
-        # Response seems interesting, so stop here      
+        # Response seems interesting, so stop here
         break
-      
+
       if not bCheckRet:
         continue # no return checking desired, so be fine
 
@@ -135,7 +135,7 @@ class LCDProc(LcdBase):
 
       if reply == 'success\n':
         continue
-      
+
       ret = False
 
     # Leave information something undesired happened
@@ -238,7 +238,7 @@ class LCDProc(LcdBase):
     rematch_imon = "SoundGraph iMON(.*)LCD"
     rematch_mdm166a = "Targa(.*)mdm166a"
     rematch_imonvfd = "Soundgraph(.*)VFD"
-    
+
     bUseExtraIcons = settings_getUseExtraElements()
 
     # Never cause script failure/interruption by this! This is totally optional!
@@ -284,7 +284,7 @@ class LCDProc(LcdBase):
       ip = settings_getHostIp()
       port = settings_getHostPort()
       log(xbmc.LOGDEBUG,"Open " + str(ip) + ":" + str(port))
-      
+
       self.tn.open(ip, port)
       # Start a new session
       self.tn.write("hello\n")
@@ -292,7 +292,7 @@ class LCDProc(LcdBase):
       # Receive LCDproc data to determine row and column information
       reply = self.tn.read_until("\n",3)
       log(xbmc.LOGDEBUG,"Reply: " + reply)
-      
+
       # parse reply by regex
       lcdinfo = re.match("^connect .+ protocol ([0-9\.]+) lcd wid (\d+) hgt (\d+) cellwid (\d+) cellhgt (\d+)$", reply)
 
@@ -319,10 +319,13 @@ class LCDProc(LcdBase):
         self.m_iBigDigits = 0 # No clock
       elif self.m_iColumns < 17:
         self.m_iBigDigits = 5 # HH:MM
-      elif self.m_iColumns < 20:
-        self.m_iBigDigits = 7 # H:MM:SS on play, HH:MM on clock
       else:
-        self.m_iBigDigits = 8 # HH:MM:SS
+        self.m_iBigDigits = 7 # H:MM:SS on play, HH:MM on clock
+
+      #elif self.m_iColumns < 20:
+      #  self.m_iBigDigits = 7 # H:MM:SS on play, HH:MM on clock
+      #else:
+      #  self.m_iBigDigits = 8 # HH:MM:SS
 
       # Check LCDproc if we can enable any extras or override values
       # (might override e.g. m_iBigDigits!)
@@ -340,7 +343,7 @@ class LCDProc(LcdBase):
 
     if not self.SetupScreen():
       log(xbmc.LOGERROR, "Screen setup failed!")
-      return False      
+      return False
 
     return True
 
@@ -477,7 +480,7 @@ class LCDProc(LcdBase):
     for i in range(int(iStringOffset), int(iStringLength)):
       if self.m_strDigits[iDigitCount] != strTimeString[i] or bForceUpdate:
         self.m_strDigits[iDigitCount] = strTimeString[i]
-        
+
         if strTimeString[i] == ":":
           self.m_strSetLineCmds += "widget_set xbmc lineBigDigit%i %i 10\n" % (iDigitCount, iOffset)
         elif strTimeString[i].isdigit():
@@ -496,11 +499,11 @@ class LCDProc(LcdBase):
       if self.m_strDigits[iDigitCount] != "" or bForceUpdate:
         self.m_strDigits[iDigitCount] = ""
         self.m_strSetLineCmds += "widget_set xbmc lineBigDigit" + str(iDigitCount) + " 0 0\n"
-      
+
       iDigitCount += 1
 
   def SetProgressBar(self, percent, pxWidth):
-    self.m_iProgressBarWidth = int(float(percent) * pxWidth)
+    self.m_iProgressBarWidth = int((float(percent)/100) * pxWidth)
     return self.m_iProgressBarWidth
 
   def SetPlayingStateIcon(self):
@@ -573,7 +576,7 @@ class LCDProc(LcdBase):
       strLineLong = strLine
 
     strLineLong.strip()
-  
+
     iMaxLineLen = dictDescriptor['endx'] - (int(dictDescriptor['startx']) - 1)
     iScrollSpeed = settings_getScrollDelay()
     strScrollMode = settings_getLCDprocScrollMode()
@@ -581,7 +584,7 @@ class LCDProc(LcdBase):
     if len(strLineLong) > iMaxLineLen: # if the string doesn't fit the display...
       if iScrollSpeed != 0:          # add separator when scrolling enabled
         if strScrollMode == "m":     # and scrollmode is marquee
-          strLineLong += self.m_strScrollSeparator      
+          strLineLong += self.m_strScrollSeparator
       else:                                       # or cut off
         strLineLong = strLineLong[:iMaxLineLen]
         iScrollSpeed = 1
@@ -613,7 +616,7 @@ class LCDProc(LcdBase):
     if dictDescriptor['type'] == LCD_LINETYPE.LCD_LINETYPE_ICONTEXT:
       if self.m_strLineIcon[iLine] != self.m_strIconName or bExtraForce:
         self.m_strLineIcon[iLine] = self.m_strIconName
-        
+
         self.m_strSetLineCmds += "widget_set xbmc lineIcon%i 1 %i %s\n" % (ln, ln, self.m_strIconName)
 
   def ClearDisplay(self):


### PR DESCRIPTION
This pull request adds another one type of screen type - 'Changing Volume'. It is (should be) displayed only when volume change buttons are pressed (or volume is changed using other means). Technically this screen is displayed when volume icon is displayed on GUI.

By default only two lines are displayed - textually with volume level and as progress bar.

Sorry for many blank changes, my IDE (Eclipse) did it :-).

TODO: I couldn't make it work when sound is muted - in proposing request screen 'Changing Volume' is shown constantly when volume level is 0% (-60 dB).

Any comments are welcome.