### PR TITLE
Add forced 4-digit big clock mode in LCD.xml

### DIFF
--- a/resources/LCD.xml.defaults
+++ b/resources/LCD.xml.defaults
@@ -20,6 +20,9 @@
    <!-- centerbigdigits: (try to) align big numbers centered on the display (on/off) -->
    <!--centerbigdigits>off</centerbigdigits-->
 
+   <!-- fourdigitbigclock: force using four digit clock (with big digits) on large (>= 20 cols) displays (on/off) -->
+   <!--fourdigitbigclock>off</fourdigitbigclock-->
+
    <!-- disableplayindicatoronpause: turn off any playing indicator (extra stuff) when pausing playback (on/off) -->
    <!--disableplayindicatoronpause>off</disableplayindicatoronpause-->
 

--- a/resources/lib/lcdbase.py
+++ b/resources/lib/lcdbase.py
@@ -313,7 +313,6 @@ class LcdBase():
 
         fourdigitbigclock = element.find("fourdigitbigclock")
         if fourdigitbigclock != None:
-          log(LOGWARNING, "fourdigitbigclock setting value: %s" % (fourdigitbigclock.text))
           if str(fourdigitbigclock.text).lower() in ["on", "true"]:
             self.m_bFourDigitBigClock = True
 

--- a/resources/lib/lcdbase.py
+++ b/resources/lib/lcdbase.py
@@ -79,6 +79,7 @@ class LcdBase():
     self.m_extraBars = [None] * (LCD_EXTRABARS_MAX + 1)
     self.m_bAllowEmptyLines = False
     self.m_bCenterBigDigits = False
+    self.m_bFourDigitBigClock = False
     self.m_bDisablePlayIndicatorOnPause = False
     self.m_bProgressbarSurroundings = False
     self.m_iDimOnPlayDelay = 0
@@ -306,6 +307,15 @@ class LcdBase():
         if centerbigdigits != None:
           if str(centerbigdigits.text).lower() in ["on", "true"]:
             self.m_bCenterBigDigits = True
+
+        # check for fourdigitbigclock setting
+        self.m_bFourDigitBigClock = False
+
+        fourdigitbigclock = element.find("fourdigitbigclock")
+        if fourdigitbigclock != None:
+          log(LOGWARNING, "fourdigitbigclock setting value: %s" % (fourdigitbigclock.text))
+          if str(fourdigitbigclock.text).lower() in ["on", "true"]:
+            self.m_bFourDigitBigClock = True
 
         # check for disableplayindicatoronpause setting
         self.m_bDisablePlayIndicatorOnPause = False

--- a/resources/lib/lcdproc.py
+++ b/resources/lib/lcdproc.py
@@ -430,9 +430,9 @@ class LCDProc(LcdBase):
       if ret == "": # no usable timestring, e.g. not playing anything
         strSysTime = self.m_InfoLabels.GetSystemTime()
 
-        if self.m_iBigDigits >= 8: # return h:m:s
+        if self.m_iBigDigits >= 8 and self.m_bFourDigitBigClock == False: # return h:m:s
           ret = strSysTime
-        elif self.m_iBigDigits >= 5: # return h:m when display too small
+        elif self.m_iBigDigits >= 5: # return h:m when display too small or if configured so in LCD.xml
           ret = strSysTime[:5]
 
       return ret


### PR DESCRIPTION
Add possibility to force 4-digit `TimeWide` InfoLabel for clock with current time
(with format `mm:ss`) on displays with 20 and more columns.

By default format `hh:mm:ss` is used, which usually doesn't look good on LCD.