### PR TITLE
Add setting to display clock using 3,4,5 or 6 big digits

### DIFF
--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -51,7 +51,12 @@ msgctxt "#32107"
 msgid "Support for extra display elements (e.g. icons)"
 msgstr "Zusatzdisplayelemente (z.B. Icons) unterstützen"
 
-# empty strings from id 32108 to 32199
+msgctxt "#32108"
+msgid "System time format"
+msgstr "Systemzeitformat"
+
+
+# empty strings from id 32109 to 32199
 # Backlight
 
 msgctxt "#32200"
@@ -151,7 +156,26 @@ msgctxt "#32417"
 msgid "HD44780-ROM A02"
 msgstr "HD44780-ROM A02"
 
-# empty strings from id 32418 to 32499
+# empty strings from id 32418 to 32420
+# Enum values: System time format
+
+msgctxt "#32421"
+msgid "H:MM"
+msgstr ""
+
+msgctxt "#32422"
+msgid "HH:MM"
+msgstr ""
+
+msgctxt "#32423"
+msgid "H:MM:SS"
+msgstr ""
+
+msgctxt "#32424"
+msgid "HH:MM:SS"
+msgstr ""
+
+# empty strings from id 32425 to 32499
 # Notifications
 
 msgctxt "#32500"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -51,7 +51,11 @@ msgctxt "#32107"
 msgid "Support for extra display elements (e.g. icons)"
 msgstr ""
 
-# empty strings from id 32108 to 32199
+msgctxt "#32108"
+msgid "System time format"
+msgstr ""
+
+# empty strings from id 32109 to 32199
 # Backlight
 
 msgctxt "#32200"
@@ -151,7 +155,26 @@ msgctxt "#32417"
 msgid "HD44780-ROM A02"
 msgstr ""
 
-# empty strings from id 32418 to 32499
+# empty strings from id 32418 to 32420
+# Enum values: System time format
+
+msgctxt "#32421"
+msgid "H:MM"
+msgstr ""
+
+msgctxt "#32422"
+msgid "HH:MM"
+msgstr ""
+
+msgctxt "#32423"
+msgid "H:MM:SS"
+msgstr ""
+
+msgctxt "#32424"
+msgid "HH:MM:SS"
+msgstr ""
+
+# empty strings from id 32425 to 32499
 # Notifications
 
 msgctxt "#32500"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -50,7 +50,11 @@ msgctxt "#32107"
 msgid "Support for extra display elements (e.g. icons)"
 msgstr "Gestion des éléments d'affichage supplémentaires (ex. icônes)"
 
-# empty strings from id 32108 to 32199
+msgctxt "#32108"
+msgid "System time format"
+msgstr "Format de l'heure système"
+
+# empty strings from id 32109 to 32199
 # Backlight
 msgctxt "#32200"
 msgid "Backlight"
@@ -146,8 +150,28 @@ msgctxt "#32417"
 msgid "HD44780-ROM A02"
 msgstr "HD44780-ROM A02"
 
-# empty strings from id 32418 to 32499
+# empty strings from id 32418 to 32420
+# Enum values: System time format
+
+msgctxt "#32421"
+msgid "H:MM"
+msgstr ""
+
+msgctxt "#32422"
+msgid "HH:MM"
+msgstr ""
+
+msgctxt "#32423"
+msgid "H:MM:SS"
+msgstr ""
+
+msgctxt "#32424"
+msgid "HH:MM:SS"
+msgstr ""
+
+# empty strings from id 32425 to 32499
 # Notifications
+
 msgctxt "#32500"
 msgid "Failed to connect to LCDProc!"
 msgstr "Échec lors de la connexion à LCDProc !"

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -51,7 +51,11 @@ msgctxt "#32107"
 msgid "Support for extra display elements (e.g. icons)"
 msgstr "Wsparcie dla dodatkowych elementów wyświetlających (np. ikon)"
 
-# empty strings from id 32108 to 32199
+msgctxt "#32108"
+msgid "System time format"
+msgstr "Format czasu systemowego"
+
+# empty strings from id 32109 to 32199
 # Backlight
 
 msgctxt "#32200"
@@ -151,7 +155,26 @@ msgctxt "#32417"
 msgid "HD44780-ROM A02"
 msgstr "HD44780-ROM A02"
 
-# empty strings from id 32418 to 32499
+# empty strings from id 32418 to 32420
+# Enum values: System time format
+
+msgctxt "#32421"
+msgid "H:MM"
+msgstr ""
+
+msgctxt "#32422"
+msgid "HH:MM"
+msgstr ""
+
+msgctxt "#32423"
+msgid "H:MM:SS"
+msgstr ""
+
+msgctxt "#32424"
+msgid "HH:MM:SS"
+msgstr ""
+
+# empty strings from id 32425 to 32499
 # Notifications
 
 msgctxt "#32500"

--- a/resources/lib/infolabels.py
+++ b/resources/lib/infolabels.py
@@ -102,7 +102,7 @@ class InfoLabels():
         # apply some split magic for 12h format here, as "hh:mm:ss"
         # makes up for format guessing inside XBMC - fix for post-frodo at
         # https://github.com/xbmc/xbmc/pull/2321
-        ret = "0" + self.GetInfoLabel("System.Time(hh:mm:ss)").split(" ")[0]
+        ret = self.GetInfoLabel("System.Time(%s)" % self._settings.getSysTimeFormat()).split(" ")[0]
         return ret[-8:]
 
     def GetPlayerTime(self):

--- a/resources/lib/lcdproc.py
+++ b/resources/lib/lcdproc.py
@@ -458,8 +458,8 @@ class LCDProc(LcdBase):
       iOffset = 1;
 
     if self.m_iOffset != iOffset:
-      # on offset change, reset numbers (only) to force redraw
-      self.ClearBigDigits(False)
+      # on offset change force redraw
+      bForceUpdate = True
       self.m_iOffset = iOffset
 
     for i in range(int(iStringOffset), int(iStringLength)):

--- a/resources/lib/settings.py
+++ b/resources/lib/settings.py
@@ -49,6 +49,7 @@ class Settings():
         self._usealternatecharset = False
         self._charset             = "iso-8859-1"
         self._useextraelements    = True
+        self._systimeformat       = 3
 
     def getHostIp(self):
         return self._hostip
@@ -96,6 +97,20 @@ class Settings():
 
     def getHideConnPopups(self):
         return self._hideconnpopups
+
+    def getSysTimeFormat(self):
+        # make sure to keep this in sync with settings.xml!
+        ret = "HH:mm:ss"
+        if self._systimeformat == "0":
+            ret = "H:mm"
+        elif self._systimeformat == "1":
+            ret = "HH:mm"
+        elif self._systimeformat == "2":
+            ret = "H:mm:ss"
+        elif self._systimeformat == "3":
+            ret = "HH:mm:ss"
+
+        return ret
 
     def getCharset(self):
         ret = ""
@@ -197,6 +212,7 @@ class Settings():
         hideconnpopups = KODI_ADDON_SETTINGS.getSetting("hideconnpopups") == "true"
         usealternatecharset = KODI_ADDON_SETTINGS.getSetting("usealternatecharset") == "true"
         charset = KODI_ADDON_SETTINGS.getSetting("charset")
+        systimeformat = KODI_ADDON_SETTINGS.getSetting("systimeformat")
 
         if self._scrolldelay != scrolldelay:
             self._scrolldelay = scrolldelay
@@ -248,6 +264,10 @@ class Settings():
 
         if self._charset != charset:
             self._charset = charset
+            self._settingsChanged = True
+
+        if self._systimeformat != systimeformat:
+            self._systimeformat = systimeformat
             self._settingsChanged = True
 
     # handles all settings and applies them as needed

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -10,6 +10,7 @@
     <setting id="charset" enable="eq(-1,true)" type="enum" label="32106" lvalues="32411|32412|32413|32414|32415|32416|32417" default="0" subsetting="true"/>
     <setting id="sep2" type="sep" />
     <setting id="useextraelements" type="bool" label="32107" default="true" />
+    <setting id="systimeformat" type="enum" label="32108" lvalues="32421|32422|32423|32424" default="0"/>
   </category>
   <category label="32200">
     <setting label="32206" type="lsep" />


### PR DESCRIPTION
Allows to specify shorter format for large (>16 columns) displays

@herrnst Is it something you thought for for displaying system time using 4 digits?

I'm not sure how to format system time to match locale (12/24h) setting

