### PR TITLE
replace getiterator with iter

### DIFF
--- a/resources/lib/lcdbase.py
+++ b/resources/lib/lcdbase.py
@@ -247,7 +247,7 @@ class LcdBase():
       log(LOGERROR, "Parsing of %s failed" % (xmlFile))
       return False
 
-    for element in doc.getiterator():
+    for element in doc.iter():
       #PARSE LCD infos
       if element.tag == "lcd":
         # load our settings


### PR DESCRIPTION
getiterator was deprecated but now already removed in python 3.9.x, iter
should work for pyton 3.x versions

Signed-off-by: BlackEagle <ike.devolder@gmail.com>