### PR TITLE
UTF-8

### DIFF
--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -156,7 +156,11 @@ msgctxt "#32417"
 msgid "HD44780-ROM A02"
 msgstr "HD44780-ROM A02"
 
-# empty strings from id 32418 to 32420
+msgctxt "#32418"
+msgid "UTF-8"
+msgstr "UTF-8"
+
+# empty strings from id 32419 to 32420
 # Enum values: System time format
 
 msgctxt "#32421"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -155,7 +155,11 @@ msgctxt "#32417"
 msgid "HD44780-ROM A02"
 msgstr ""
 
-# empty strings from id 32418 to 32420
+msgctxt "#32418"
+msgid "UTF-8"
+msgstr ""
+
+# empty strings from id 32419 to 32420
 # Enum values: System time format
 
 msgctxt "#32421"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -150,7 +150,11 @@ msgctxt "#32417"
 msgid "HD44780-ROM A02"
 msgstr "HD44780-ROM A02"
 
-# empty strings from id 32418 to 32420
+msgctxt "#32418"
+msgid "UTF-8"
+msgstr "UTF-8"
+
+# empty strings from id 32419 to 32420
 # Enum values: System time format
 
 msgctxt "#32421"

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -155,7 +155,11 @@ msgctxt "#32417"
 msgid "HD44780-ROM A02"
 msgstr "HD44780-ROM A02"
 
-# empty strings from id 32418 to 32420
+msgctxt "#32418"
+msgid "UTF-8"
+msgstr "UTF-8"
+
+# empty strings from id 32419 to 32420
 # Enum values: System time format
 
 msgctxt "#32421"

--- a/resources/lib/settings.py
+++ b/resources/lib/settings.py
@@ -132,6 +132,8 @@ class Settings():
                 ret = "hd44780-a00"
             elif self._charset == "6":
                 ret = "hd44780-a02"
+            elif self._charset == "7":
+                ret = "utf-8"
             else:
                 ret = "iso-8859-1"
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -7,7 +7,7 @@
     <setting id="refreshrate" type="slider" label="32104" option="int" default="1" range="1,20" />
     <setting id="sep1" type="sep" />
     <setting id="usealternatecharset" type="bool" label="32105" default="false" />
-    <setting id="charset" enable="eq(-1,true)" type="enum" label="32106" lvalues="32411|32412|32413|32414|32415|32416|32417" default="0" subsetting="true"/>
+    <setting id="charset" enable="eq(-1,true)" type="enum" label="32106" lvalues="32411|32412|32413|32414|32415|32416|32417|32418" default="0" subsetting="true"/>
     <setting id="sep2" type="sep" />
     <setting id="useextraelements" type="bool" label="32107" default="true" />
     <setting id="systimeformat" type="enum" label="32108" lvalues="32421|32422|32423|32424" default="0"/>


### PR DESCRIPTION
I created a new OLEDproc add-on. It's like LCDproc, but for graphic OLED displays. There are changes in my PR that allow you to use UTF-8 charset, which is native to Kodi.

Note: 
I didn't make a change in the add-on version, only in the code.