### PR TITLE
Fix SyntaxWarning on regex invalid escape sequences

### DIFF
--- a/resources/lib/lcdbase.py
+++ b/resources/lib/lcdbase.py
@@ -366,7 +366,7 @@ class LcdBase():
       return
 
     # regex to determine any of $INFO[LCD.Time(Wide)21-44]
-    timeregex = r'' + re.escape('$INFO[LCD.') + 'Time((Wide)?\d?\d?)' + re.escape(']')
+    timeregex = r'' + re.escape('$INFO[LCD.') + r'Time((Wide)?\d?\d?)' + re.escape(']')
 
     for line in node.findall("line"):
       # initialize line with empty descriptor
@@ -414,7 +414,7 @@ class LcdBase():
       elif linetext.lower().find("$info[lcd.playicon]") >= 0:
         linedescriptor['type'] = LCD_LINETYPE.LCD_LINETYPE_ICONTEXT
         linedescriptor['startx'] = int(1 + self.m_iIconTextOffset) # icon widgets take 2 chars, so shift text offset (default: 2)
-        linedescriptor['text'] = re.sub(r'\s?' + re.escape("$INFO[LCD.PlayIcon]") + '\s?', ' ', linetext, flags=re.IGNORECASE).strip()
+        linedescriptor['text'] = re.sub(r'\s?' + re.escape("$INFO[LCD.PlayIcon]") + r'\s?', ' ', linetext, flags=re.IGNORECASE).strip()
 
       # standard (scrolling) text line
       else:
@@ -427,8 +427,8 @@ class LcdBase():
       if linetext.lower().find("$info[lcd.alignright]") >= 0:
         linedescriptor['align'] = LCD_LINEALIGN.LCD_LINEALIGN_RIGHT
 
-      linedescriptor['text'] = re.sub(r'\s?' + re.escape("$INFO[LCD.AlignCenter]") + '\s?', ' ', linedescriptor['text'], flags=re.IGNORECASE).strip()
-      linedescriptor['text'] = re.sub(r'\s?' + re.escape("$INFO[LCD.AlignRight]") + '\s?', ' ', linedescriptor['text'], flags=re.IGNORECASE).strip()
+      linedescriptor['text'] = re.sub(r'\s?' + re.escape("$INFO[LCD.AlignCenter]") + r'\s?', ' ', linedescriptor['text'], flags=re.IGNORECASE).strip()
+      linedescriptor['text'] = re.sub(r'\s?' + re.escape("$INFO[LCD.AlignRight]") + r'\s?', ' ', linedescriptor['text'], flags=re.IGNORECASE).strip()
 
       self.m_lcdMode[mode].append(linedescriptor)
 
@@ -475,7 +475,7 @@ class LcdBase():
     return ret
 
   def StripBBCode(self, strtext):
-    regexbbcode = "\[(?P<tagname>[0-9a-zA-Z_\-]+?)[0-9a-zA-Z_\- ]*?\](?P<content>.*?)\[\/(?P=tagname)\]"
+    regexbbcode = r"\[(?P<tagname>[0-9a-zA-Z_\-]+?)[0-9a-zA-Z_\- ]*?\](?P<content>.*?)\[\/(?P=tagname)\]"
     # precompile and remember regex to make sure re's caching won't cause accidential recompilation
     if not self.m_reBBCode:
       self.m_reBBCode = re.compile(regexbbcode)
@@ -494,7 +494,7 @@ class LcdBase():
     while True:
       loopcount = loopcount - 1
       try:
-        mangledline, replacements = re.subn(self.m_reBBCode, "\g<content>", mangledline)
+        mangledline, replacements = re.subn(self.m_reBBCode, r"\g<content>", mangledline)
       except:
         return mangledline
 

--- a/resources/lib/lcdproc.py
+++ b/resources/lib/lcdproc.py
@@ -264,7 +264,7 @@ class LCDProc(LcdBase):
       log(LOGDEBUG,"Reply: " + reply)
 
       # parse reply by regex
-      lcdinfo = re.match("^connect .+ protocol ([0-9\.]+) lcd wid (\d+) hgt (\d+) cellwid (\d+) cellhgt (\d+)$", reply)
+      lcdinfo = re.match(r"^connect .+ protocol ([0-9\.]+) lcd wid (\d+) hgt (\d+) cellwid (\d+) cellhgt (\d+)$", reply)
 
       # if regex didn't match, LCDproc is incompatible or something's odd
       if lcdinfo is None:


### PR DESCRIPTION
Use raw string for regex with escape sequences. Was previously a silent DeprecationWarning but with Python 3.12 it becomes a SyntaxWarning and for future Python releases it will become a SyntaxError.

```
2024-09-26 22:01:28.483 T:7003    error <general>: /home/kodi/.kodi/addons/script.xbmc.lcdproc/resources/lib/lcdproc.py
2024-09-26 22:01:28.483 T:7003    error <general>: :283:
2024-09-26 22:01:28.483 T:7003    error <general>: SyntaxWarning
2024-09-26 22:01:28.483 T:7003    error <general>: :
2024-09-26 22:01:28.483 T:7003    error <general>: invalid escape sequence '\.'
2024-09-26 22:01:28.483 T:7003    error <general>:

2024-09-26 22:01:28.484 T:7003    error <general>:
2024-09-26 22:01:28.485 T:7003    error <general>: lcdinfo = re.match("^connect .+ protocol ([0-9\.]+) lcd wid (\d+) hgt (\d+) cellwid (\d+) cellhgt (\d+)$", reply)
2024-09-26 22:01:28.485 T:7003    error <general>:

2024-09-26 22:01:28.517 T:7003    error <general>: /home/kodi/.kodi/addons/script.xbmc.lcdproc/resources/lib/lcdbase.py:385: SyntaxWarning: invalid escape sequence '\d'
                                                     timeregex = r'' + re.escape('$INFO[LCD.') + 'Time((Wide)?\d?\d?)' + re.escape(']')

2024-09-26 22:01:28.517 T:7003    error <general>: /home/kodi/.kodi/addons/script.xbmc.lcdproc/resources/lib/lcdbase.py:433: SyntaxWarning: invalid escape sequence '\s'
                                                     linedescriptor['text'] = re.sub(r'\s?' + re.escape("$INFO[LCD.PlayIcon]") + '\s?', ' ', linetext, flags=re.IGNORECASE).strip()

2024-09-26 22:01:28.517 T:7003    error <general>: /home/kodi/.kodi/addons/script.xbmc.lcdproc/resources/lib/lcdbase.py:446: SyntaxWarning: invalid escape sequence '\s'
                                                     linedescriptor['text'] = re.sub(r'\s?' + re.escape("$INFO[LCD.AlignCenter]") + '\s?', ' ', linedescriptor['text'], flags=re.IGNORECASE).strip()

2024-09-26 22:01:28.517 T:7003    error <general>: /home/kodi/.kodi/addons/script.xbmc.lcdproc/resources/lib/lcdbase.py:447: SyntaxWarning: invalid escape sequence '\s'
                                                     linedescriptor['text'] = re.sub(r'\s?' + re.escape("$INFO[LCD.AlignRight]") + '\s?', ' ', linedescriptor['text'], flags=re.IGNORECASE).strip()

2024-09-26 22:01:28.518 T:7003    error <general>: /home/kodi/.kodi/addons/script.xbmc.lcdproc/resources/lib/lcdbase.py:494: SyntaxWarning: invalid escape sequence '\['
                                                     regexbbcode = "\[(?P<tagname>[0-9a-zA-Z_\-]+?)[0-9a-zA-Z_\- ]*?\](?P<content>.*?)\[\/(?P=tagname)\]"

2024-09-26 22:01:28.518 T:7003    error <general>: /home/kodi/.kodi/addons/script.xbmc.lcdproc/resources/lib/lcdbase.py:513: SyntaxWarning: invalid escape sequence '\g'
                                                     mangledline, replacements = re.subn(self.m_reBBCode, "\g<content>", mangledline)
```

Only logged on initial compile of pycache so need to delete ~/.kodi/addons/script.xbmc.lcdproc/resources/lib/\_\_pycache\_\_/ to (re)observe.